### PR TITLE
Feature/add tcp service

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ helm upgrade teamspeak \
     --namespace default \
     -f ./chart/values.yaml
 ```
+NB: Limited support for TCP ports. See [Known Limitations](#known-limitations)
 
 ## Installing the chart
 The [configuration](#configuration) section lists
@@ -57,30 +58,48 @@ and deletes the release.
 The following table lists the configurable parameters of the chart and their default
 values.
 
-| Parameter                   | Description                                               | Default         |
-|-----------------------------|-----------------------------------------------------------|-----------------|
-| `image.repository`          | Image repository                                          | `teamspeak`     |
-| `image.tag`                 | Image tag                                                 | `3.12.0`        |
-| `image.pullPolicy`          | Image pull policy                                         | `Always`        |
-| `image.pullSecret`          | Specify image pull secrets                                | `nil`           |
-| `pod.annotations`           | Specify annotations for the pod                           | `nil`           |
-| `service.type`              | Specify the service type - only LB and NodePort supported | `LoadBalancer`  |
-| `service.nodePort`          | Specify the service nodePort                              | `30987`         |
-| `resources`                 | Kubernetes resources                                      | `nil`           |
-| `nodeSelector`              | Kubernetes nodeSelectors for the deployment               | `nil`           |
-| `tolerations`               | Kubernetes tolerations for the deployment                 | `nil`           |
-| `affinity`                  | Kubernetes affinities for the deployment                  | `nil`           |
-| `persistence.enabled`       | Enable/Disable persistence                                | `disabled`      |
-| `persistence.accessMode`    | Accessmode for the PVC                                    | `nil`           |
-| `persistence.existingClaim` | Name of an existing PVC to use                            | `nil`           |
-| `persistence.annotations`   | Annotations for the PVC                                   | `nil`           |
-| `persistence.storageClass`  | StorageClass for the PVC                                  | `nil`           |
-| `persistence.storageSize`   | Size of the PVC                                           | `nil`           |
+| Parameter                   | Description                                                                                 | Default         |
+|-----------------------------|---------------------------------------------------------------------------------------------|-----------------|
+| `image.repository`          | Image repository                                                                            | `teamspeak`     |
+| `image.tag`                 | Image tag                                                                                   | `3.12.0`        |
+| `image.pullPolicy`          | Image pull policy                                                                           | `Always`        |
+| `image.pullSecret`          | Specify image pull secrets                                                                  | `nil`           |
+| `pod.annotations`           | Specify annotations for the pod                                                             | `nil`           |
+| `service.type`              | Specify the service type - only LB and NodePort supported                                   | `LoadBalancer`  |
+| `service.ip`                | Specify the requested IP Address - only LB supported                                        | `nil`           |
+| `service.nodePort`          | Specify the service nodePort                                                                | `30987`         |
+| `service.tcp.enabled`       | Enable/Disable TCP ports - limited support - See [TCP configuration](#tcp-configuration)    | `disabled`      |
+| `service.tcp.type`          | Specify the tcp implementation type - See [TCP configuration](#tcp-configuration)           | `seperate`      |
+| `service.annotations`       | Annotations for the service                                                                 | `nil`           | 
+| `resources`                 | Kubernetes resources                                                                        | `nil`           |
+| `nodeSelector`              | Kubernetes nodeSelectors for the deployment                                                 | `nil`           |
+| `tolerations`               | Kubernetes tolerations for the deployment                                                   | `nil`           |
+| `affinity`                  | Kubernetes affinities for the deployment                                                    | `nil`           |
+| `persistence.enabled`       | Enable/Disable persistence                                                                  | `disabled`      |
+| `persistence.accessMode`    | Accessmode for the PVC                                                                      | `nil`           |
+| `persistence.existingClaim` | Name of an existing PVC to use                                                              | `nil`           |
+| `persistence.annotations`   | Annotations for the PVC                                                                     | `nil`           |
+| `persistence.storageClass`  | StorageClass for the PVC                                                                    | `nil`           |
+| `persistence.storageSize`   | Size of the PVC                                                                             | `nil`           |
+
+## TCP Configuration
+This chart currently has limited support for TCP ports. See [Known Limitations](#known-limitations)  
+[Check]((https://github.com/janosi/enhancements/blob/mixedprotocollb/keps/sig-network/20200103-mixed-protocol-lb.md#implementation-detailsnotesconstraints)) if your enviorment supports `mixed protocols`.
+
+### How to Enable TCP
+See [TCP configuration](./docs/tcp-configuration.md)
 
 ## Accessing the server
 After deploying the helm chart, you will see instructions to access your server in the commandline's stdout.
 
-## Known Restrictions
-1. This chart currently only supports the UDP ports used for TS3. This means you can access and manage only the single
+## Known Limitations
+1. This chart currently only supports the TCP ports if:
+    * the `service.type` is of type `LoadBalancer`; and
+    * the ``LoadBalancer`` supports mixing both `UDP` and `TCP` ports. 
+    (See [official support request](https://github.com/kubernetes/kubernetes/issues/23880))
+
+To configure TCP in supported environments see [TCP configuration](./docs/tcp-configuration.md)
+
+This means you can access and manage only the single
 default virtual server inside the Teamspeak server. If you want to manage multiple server, you can simply deploy this
 chart multiple times.

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: teamspeak
 sources:
 - https://github.com/ksandermann/teamspeak-helm-chart
-version: 0.1.1
+version: 0.2.0
 appVersion: 3.12.0

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: teamspeak
 sources:
 - https://github.com/ksandermann/teamspeak-helm-chart
-version: 0.1.0
-appVersion: 3.9.1
+version: 0.1.1
+appVersion: 3.12.0

--- a/chart/templates/service-tcp.yaml
+++ b/chart/templates/service-tcp.yaml
@@ -1,7 +1,8 @@
+{{- if and (.Values.service.tcp.enabled) (eq .Values.service.tcp.type "seperate")}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Release.Name }}-tcp
   labels:
     app: teamspeak
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -17,21 +18,15 @@ spec:
   loadBalancerIP: {{ .Values.service.ip }}
   {{- end }}
   ports:
-    - nodePort: {{ .Values.service.nodePort }}
-      targetPort: 9987
-      protocol: UDP
-      name: teamspeak-voice
-      port: 9987
-    {{- if and (.Values.service.tcp.enabled) (eq .Values.service.tcp.type "combined") }}
-    - name: teamspeak-filetransfer
-      port: 30033
-      targetPort: 30033
-      protocol: UDP
-    - name: teamspeak-serverquery
-      port: 10011
-      targetPort: 10011
-      protocol: UDP
-    {{- end}}
+  - name: teamspeak-filetransfer
+    port: 30033
+    protocol: TCP
+    targetPort: 30033
+  - name: teamspeak-serverquery
+    port: 10011
+    protocol: TCP
+    targetPort: 10011
   selector:
     app: teamspeak
     release: {{ .Release.Name }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,13 +2,30 @@ image:
   repository: teamspeak
   tag: 3.12.0
   pullPolicy: Always
-  # Secret must be manually created in the namespace.
+  ## Secret must be manually created in the namespace.
   # pullSecret: "nexus-pull-secret"
 podAnnotations: {}
-#only NodePort and LoadBalancer supported, as this is UDP traffic
+## only NodePort and LoadBalancer supported, as this is UDP traffic
 service:
   type: LoadBalancer
+  ## ip requests a specific IP address from the LoadBalancer (Supportd only for LoadBalancer)
+  #ip: "IPAddress"
   nodePort: 30987
+  ## tcp.enabled creates the TCP service if true (supported only if your LB implementation suports both TCP and UDP)
+  ## Needed until https://github.com/kubernetes/kubernetes/issues/23880 is implemented
+  ## See https://github.com/janosi/enhancements/blob/mixedprotocollb/keps/sig-network/20200103-mixed-protocol-lb.md#implementation-detailsnotesconstraints
+  ## Some mixed ports implementations use an annotation to merge services
+  ## known anotations:
+    ## MetalLB - metallb.universe.tf/allow-shared-ip: [string]
+    ## Azure CPI LB - service.beta.kubernetes.io/azure-load-balancer-mixed-protocols: [bool] (Not tested)
+  tcp:
+    enabled: false
+    ## type sets the implementation type. Values either combined | seperate. See docs.
+    type: "seperate"
+  annotations:
+    #metallb.universe.tf/allow-shared-ip: "{{ .Release.Name }}"
+    #service.beta.kubernetes.io/azure-load-balancer-mixed-protocols: "true"
+    
 resources:
   limits:
     cpu: 250m

--- a/docs/tcp-configuration.md
+++ b/docs/tcp-configuration.md
@@ -1,0 +1,32 @@
+# TCP Configuration
+This chart currently has limited support for TCP ports. See [Known Limitations](#known-limitations)  
+[Check]((https://github.com/janosi/enhancements/blob/mixedprotocollb/keps/sig-network/20200103-mixed-protocol-lb.md#implementation-detailsnotesconstraints)) if your enviorment supports `mixed protocols`.
+
+## How to Enable TCP
+ * Set `service.tcp.enabled` to `true` in the configuration option; and
+ * folow any additional specific instructions below
+
+The Following are known supported `LoadBalancers`:
+
+### MetalLB
+MetalLB supports `mixed protocols` by allowing multiple services to share the same IP address. See [IP Address Sharing](https://metallb.universe.tf/usage/#ip-address-sharing)  
+This is done by combining two services on a specfic annotation.
+
+
+Settings required:
+
+| Settings               | Value                                           | Comment                                                        |
+| -----------------------|-------------------------------------------------|----------------------------------------------------------------|
+| `services.tcp.type`    | `seperate`                                      | (default)                                                      |
+| `services.annotations` | `metallb.universe.tf/allow-shared-ip`: [string] | Where [string] is a string that uniquely identifies `shared-ip` services.|
+
+### Azure CPI LB (Untested)
+Azure supports `mixed protocols` by declaring that the ports specfied in the service are both TCP and UDP.
+This is done by specifying an annotation on a single service.
+
+Settings required:
+
+| Settings               | Value                                                                  | Comment 
+| -----------------------|------------------------------------------------------------------------|-----------------------------------------|
+| `services.tcp.type`    | `combined`                                                             |                                         |
+| `services.annotations` | `service.beta.kubernetes.io/azure-load-balancer-mixed-protocols`: true |                                         |


### PR DESCRIPTION
Adds support for TCP ports for a limited number of configurations.

- LoadBalancer required; and
- LB must support `mixed protocols`

I've tested on bare metal with MetalLB.
I've also provided a implementation for Azure (I haven't tested in Azure) as it is similar to MetalLB.

See docs for details.
